### PR TITLE
Always use remote branch for git repos

### DIFF
--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -116,7 +116,7 @@ class AutoHelm(object):
             origin = repo.create_remote('origin', (git_repo))
 
         origin.fetch()
-        repo.git.checkout(branch)
+        repo.git.checkout("origin/{}".format(branch))
 
     def install(self):
         self._update_repositories()

--- a/autohelm/meta.py
+++ b/autohelm/meta.py
@@ -1,3 +1,3 @@
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 __author__ = 'ReactiveOps, Inc.'


### PR DESCRIPTION
When the remote branch changes, this keeps us in track.