### PR TITLE
Better error handling

### DIFF
--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -117,8 +117,14 @@ class AutoHelm(object):
 
     def install(self):
         self._update_repositories()
+        failed_charts = []
         for chart in self._charts:
-            self.install_chart(chart, self._charts[chart])
+            if not self.install_chart(chart, self._charts[chart]):
+                failed_charts.append(chart)
+        if failed_charts:
+            logging.error("ERROR: Some charts failed to install.")
+            for chart in failed_charts:
+                logging.error(chart)
 
     def install_chart(self, release_name, chart):
         chart_name = chart.get('chart', release_name)
@@ -160,4 +166,4 @@ class AutoHelm(object):
 
         logging.debug(' '.join(args))
         args = map(os.path.expandvars, args)
-        subprocess.call(args)
+        return not bool(subprocess.call(args))

--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -17,13 +17,10 @@
 import oyaml as yaml
 import subprocess
 import logging
-import click
 import git
 import os
 import sys
 import re
-
-from meta import *
 
 
 class AutoHelm(object):
@@ -77,7 +74,7 @@ class AutoHelm(object):
         try:
             FNULL = open(os.devnull, 'w')
             subprocess.check_call(['helm', 'list'], stdout=FNULL, stderr=subprocess.STDOUT)
-        except subprocess.CalledProcessError, e:
+        except subprocess.CalledProcessError:
             return False
         return True
 
@@ -142,7 +139,7 @@ class AutoHelm(object):
 
             if repository_git:
                 self._fetch_git_chart(chart_name, repository_git, chart.get('version', "master"),  repository_path)
-                repository_name = repo_path = '{}/{}/{}'.format(self._archive, re.sub(r'\:\/\/|\/|\.', '_', repository_git), repository_path)
+                repository_name = '{}/{}/{}'.format(self._archive, re.sub(r'\:\/\/|\/|\.', '_', repository_git), repository_path)
             elif repository_name not in self.installed_repositories and repository_url:
                 self._intall_repository(repository_name, repository_url)
 

--- a/autohelm/meta.py
+++ b/autohelm/meta.py
@@ -1,3 +1,3 @@
 
-__version__ = '0.1.6'
+__version__ = '0.2.0'
 __author__ = 'ReactiveOps, Inc.'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
 [pycodestyle]
 max-line-length = 160
 statistics = True
+
+[pylama:pylint]
+max_line_length = 160
+
+[pylama:pycodestyle]
+max_line_length = 160
+
+[pylama:pep8]
+max_line_length = 160


### PR DESCRIPTION
Basic idea here is to avoid missing errors in the scrollback when deploying lots of charts. This summarizes them at the end and rolls back so that releases aren't left as `FAILED`. There are plenty of edge cases that aren't handled here (e.g. first-time install failures). This is also a bit gross because we're using helm cli and not grpc, but such is life right now.