### PR TITLE
Handle exit codes correctly when there are failures

### DIFF
--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -82,7 +82,7 @@ class AutoHelm(object):
             for repo in self._repositories:
                 if repo not in self.installed_repositories:
                     url = self._repositories[repo].get('url')
-                    self._intall_repository(repo, url)
+                    self._install_repository(repo, url)
 
     @property
     def current_context(self):
@@ -126,7 +126,7 @@ class AutoHelm(object):
         logging.debug(" ".join(args))
         subprocess.call(args)
 
-    def _intall_repository(self, name, url):
+    def _install_repository(self, name, url):
         """ Install Helm repository """
         args = ['helm', 'repo', 'add', name, url]
         logging.debug(" ".join(args))
@@ -338,7 +338,7 @@ class AutoHelm(object):
                 if self._fetch_git_chart(chart_name, repository_git, version,  repository_path) is False:
                     return False
             elif repository_name not in self.installed_repositories and repository_url:
-                self._intall_repository(repository_name, repository_url)
+                self._install_repository(repository_name, repository_url)
         return repository_name
 
     def install_chart(self, release_name, chart):

--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -58,19 +58,19 @@ class AutoHelm(object):
         self._archive = self._home + '/cache/archive'
         if not os.path.isdir(self._archive):
             logging.error("{} does not exist. Have you run `helm init`?".format(self._archive))
-            sys.exit()
+            sys.exit(1)
 
         logging.debug("Checking for Tiller")
         if not self._local_development and not self.tiller_present:
             logging.error("Tiller not present in cluster. Have you run `helm init`?")
-            sys.exit()
+            sys.exit(1)
 
         self._default_namespace = plan.get('namespace', 'kube-system')
         logging.debug("Default namespace: {}".format(self._default_namespace))
 
         self._default_repository = plan.get('repository', 'stable')
         logging.debug("Default repository: {}".format(self._default_repository))
-            
+
         selected_charts = charts or plan.get('charts').iterkeys()
         self._charts = {name: chart for name, chart in plan.get('charts').iteritems() if name in selected_charts}
         self._minimum_versions = plan.get('minimum_versions', None)
@@ -233,6 +233,7 @@ class AutoHelm(object):
             logging.error("ERROR: Some charts failed to install and were rolled back")
             for chart in failed_charts:
                 logging.error(" - {}".format(chart))
+            sys.exit(1)
 
     def rollback_chart(self, release_name):
         list_output = subprocess.check_output(['helm', 'list', '--deployed', release_name])
@@ -342,7 +343,7 @@ class AutoHelm(object):
 
     def install_chart(self, release_name, chart):
         chart_name = chart.get('chart', release_name)
-        repository_name = self.ensure_repository(release_name, chart_name, chart.get('repository'), chart.get('version', "master"))        
+        repository_name = self.ensure_repository(release_name, chart_name, chart.get('repository'), chart.get('version', "master"))
         if repository_name is False:
             logging.error("Unable to install chart: {}".format(chart_name))
             return False


### PR DESCRIPTION
When installing a chart that had failed, the exit code after autohelm has finished was still determined as a success.

This PR adjusts the exit code to 1 when there are failed charts
This PR also renames an incorrectly spelt function
This PR also adds non zero exit codes when logging.error occurs
