### PR TITLE
Swapping eval order so that --dry-run is always passed to helm when provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ charts:
     files:
       - /path/to/values/file.yml
 ```
+Note: The file paths will be interpreted as relative to the working directory of
+the shell calling autohelm.
 
 ### namespace
 

--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -244,10 +244,10 @@ class AutoHelm(object):
             subprocess.call(args)
 
     def debug_args(self):
-        if self._debug:
-            return ['--debug']
         if self._dryrun:
             return ['--dry-run', '--debug']
+        if self._debug:
+            return ['--debug']
         return []
 
     def _format_set(self, key, value):


### PR DESCRIPTION
Retains the functionality where `--dry-run` alone invokes helm with `--debug`
fixes https://github.com/reactiveops/autohelm/issues/51