### PR TITLE
Accept --set cli options and pass directly to helm

### DIFF
--- a/autohelm/autohelm.py
+++ b/autohelm/autohelm.py
@@ -34,12 +34,13 @@ class AutohelmException(Exception):
 
 class AutoHelm(object):
 
-    def __init__(self, file=None, dryrun=False, debug=False, charts=None, local_development=False ):
+    def __init__(self, file=None, dryrun=False, debug=False, charts=None, local_development=False, set=None):
 
         self._home = os.environ.get('HELM_HOME')
         self._dryrun = dryrun
         self._debug = debug
         self._local_development = local_development
+        self._sets = set
         if self._local_development:
             logging.info("Local Development is ON")
 
@@ -371,6 +372,9 @@ class AutoHelm(object):
         for key, value in chart.get('values-strings', {}).iteritems():
             for k, v in self._format_set(key, value):
                 args.append("--set-string={}={}".format(k, v))
+
+        for keyvalue in self._sets:
+            args.append("--set={}".format(keyvalue))
 
         args.append('--namespace={}'.format(chart.get('namespace', self._namespace)))
 

--- a/bin/autohelm
+++ b/bin/autohelm
@@ -40,9 +40,10 @@ def cli(ctx, log_level, *args, **kwargs):
 @click.option("--debug", is_flag=True, help="Pass --debug to helm")
 @click.option("--heading", "--only", metavar="<chart>", help="Only run a specific chart by name", multiple=True)
 @click.option("--local-development", is_flag=True, default=False, help="Run `autohelm` in local-development mode where Tiller is not required and no helm commands are run. Useful for rapid or offline development.")
-def plot(ctx, file=None, dry_run=False, debug=False, only=None, local_development=False):
+@click.option("--set", multiple=True, help="Passes --set parameters to helm")
+def plot(ctx, file=None, dry_run=False, debug=False, only=None, local_development=False, set=None):
     """ Install charts with given arguments as listed in yaml file argument """
-    h = AutoHelm(file=file, dryrun=dry_run, debug=debug, charts=only, local_development=local_development)
+    h = AutoHelm(file=file, dryrun=dry_run, debug=debug, charts=only, local_development=local_development, set=set)
     h.install()
 
 


### PR DESCRIPTION
You might consider this an anit-pattern in your usage but I'd like a simple way to invoke autohelm from ci/cd but pass a parameter to change a value like an image tag for instance.  If there is another way to do this, I'd like to hear what you are doing.

Making sure the version controlled values for a specific `course` get updated would be out of band but could be incorporated into autohelm as well.